### PR TITLE
stlink-1.4.0, fix FL-4356: multilib-strict check failed

### DIFF
--- a/dev-embedded/stlink/files/stlink-1.4.0.patch
+++ b/dev-embedded/stlink/files/stlink-1.4.0.patch
@@ -1,0 +1,12 @@
+--- stlink-1.4.0/CMakeLists.txt
++++ stlink-1.4.0/CMakeLists.txt
+@@ -4,7 +4,8 @@
+ set(PROJECT_DESCRIPTION "Open source version of the STMicroelectronics Stlink Tools")
+ set(STLINK_UDEV_RULES_DIR "/etc/udev/rules.d" CACHE PATH "Udev rules directory")
+ set(STLINK_MODPROBED_DIR "/etc/modprobe.d" CACHE PATH "modprobe.d directory")
+-set(STLINK_LIBRARY_PATH "lib/${CMAKE_LIBRARY_PATH}" CACHE PATH "Target lib directory")
++set(LIB_INSTALL_DIR "lib" CACHE PATH "Main library directory")
++set(STLINK_LIBRARY_PATH "${LIB_INSTALL_DIR}/${CMAKE_LIBRARY_PATH}" CACHE PATH "Target lib directory")
+ 
+ option(STLINK_GENERATE_MANPAGES "Generate manpages with pandoc" OFF)
+ 

--- a/dev-embedded/stlink/stlink-1.4.0.ebuild
+++ b/dev-embedded/stlink/stlink-1.4.0.ebuild
@@ -25,10 +25,13 @@ RDEPEND="virtual/libusb:1
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
 
+PATCHES=( "${FILESDIR}"/${P}.patch )
+
 src_configure() {
 	local mycmakeargs=(
 		-DSTLINK_UDEV_RULES_DIR="$(get_udevdir)"/rules.d
 		-DSTLINK_MODPROBED_DIR="${EPREFIX}/etc/modprobe.d"
+		-DLIB_INSTALL_DIR="${EPREFIX}/usr/$(get_libdir)"
 	)
 
 	cmake-utils_src_configure


### PR DESCRIPTION
Fix:

 * https://bugs.funtoo.org/browse/FL-4356
 * https://bugs.gentoo.org/630932

```
Files matching a file type that is not allowed:
   usr/lib/libstlink-shared.so.1.4.0
 * ERROR: dev-embedded/stlink-1.4.0::dev-kit failed:
 *   multilib-strict check failed!

```

Base:
* https://github.com/texane/stlink/issues/633 
* https://github.com/texane/stlink/blob/master/doc/compiling.md#build-using-different-directory-for-shared-libs
