### PR TITLE
/etc/mysql/my.cnf

### DIFF
--- a/dev-db/mariadb/files/my.cnf-10.2
+++ b/dev-db/mariadb/files/my.cnf-10.2
@@ -1,3 +1,28 @@
 # @GENTOO_PORTAGE_EPREFIX@/etc/mysql/my.cnf: The global mysql configuration file.
 
+[mysqld]
+character-set-server = utf8
+user = mysql
+port = 3306
+socket = /var/run/mysqld/mysqld.sock
+pid-file = /var/run/mysqld/mariadb.pid
+log-error = /var/log/mysql/mysqld.err
+basedir = /usr
+datadir = /var/lib/mysql
+skip-external-locking
+lc_messages_dir = /usr/share/mariadb
+#Set this to your desired error message language
+lc_messages = en_US
+
+# security:
+# using "localhost" in connects uses sockets by default
+# skip-networking
+bind-address = 127.0.0.1
+
+log-bin
+server-id                   = 1
+
+# point the following paths to different dedicated disks
+tmpdir                      = /tmp/
+
 !includedir @GENTOO_PORTAGE_EPREFIX@/etc/mysql/mariadb.d


### PR DESCRIPTION
may be i have missed something, but at the beginning installation, after emerge dev-db/mariadb i did:
```
emerge --config dev-db/mariadb
```
and got error message:

```
Configuring pkg...

 * Trying to get password for mysql 'root' user from 'mysql' section ...
 * Trying to get password for mysql 'root' user from 'client' section ...
 * Please provide a password for the mysql 'root' user now
 * or through the /root/.my.cnf file.
 * Avoid ["'\_%] characters in the password
    >
 * Retype the password
    >
 * Creating the mysql database and setting proper permissions on it ...
 * Command: /usr/share/mariadb/scripts/mysql_install_db --basedir=/usr --loose-skip-grant-tables --loose-skip-host-cache --loose-skip-name-resolve --loose-skip-networking --loose-skip-slave-start --loose-skip-ssl --loose-skip-log-bin --loose-skip-relay-log --loose-skip-slow-query-log --loose-skip-external-locking --loose-skip-log-slave-updates --datadir=///var/lib/mysql --tmpdir=//
my_print_defaults: [ERROR] unknown option '--mysqld'
Installing MariaDB/MySQL system tables in '///var/lib/mysql' ...
2018-09-18  0:17:45 0 [ERROR] mysqld: Can't create/write to file '/ibjaoQ5P' (Errcode: 13 "Permission denied")
2018-09-18  0:17:45 0 [ERROR] InnoDB: Unable to create temporary file; errno: 13
2018-09-18  0:17:45 0 [ERROR] mysqld: Can't create/write to file '/ibRQ3hFt' (Errcode: 13 "Permission denied")
2018-09-18  0:17:45 0 [ERROR] InnoDB: Unable to create temporary file; errno: 13
2018-09-18  0:17:45 0 [ERROR] InnoDB: Database creation was aborted with error Generic error. You may need to delete the ibdata1 file before trying to start up again.
2018-09-18  0:17:45 0 [ERROR] Plugin 'InnoDB' init function returned error.
2018-09-18  0:17:45 0 [ERROR] Plugin 'InnoDB' registration as a STORAGE ENGINE failed.
2018-09-18  0:17:45 0 [ERROR] Unknown/unsupported storage engine: InnoDB
2018-09-18  0:17:45 0 [ERROR] Aborting


Installation of system tables failed!  Examine the logs in
///var/lib/mysql for more information.

The problem could be conflicting information in an external
my.cnf files. You can ignore these by doing:

    shell> /usr/share/mariadb/scripts/mysql_install_db --defaults-file=~/.my.cnf

You can also try to start the mysqld daemon with:

    shell> /usr/sbin/mysqld --skip-grant-tables --general-log &

and use the command line tool /usr/bin/mysql
to connect to the mysql database and look at the grant tables:

    shell> /usr/bin/mysql -u root mysql
    mysql> show tables;

Try 'mysqld --help' if you have problems with paths.  Using
--general-log gives you a log in ///var/lib/mysql that may be helpful.

The latest information about mysql_install_db is available at
https://mariadb.com/kb/en/installing-system-tables-mysql_install_db
You can find the latest source at https://downloads.mariadb.org and
the maria-discuss email list at https://launchpad.net/~maria-discuss

Please check all of the above before submitting a bug report
at http://mariadb.org/jira

 * ERROR: dev-db/mariadb-10.3.8::dev-kit failed (config phase):
 *   Failed to initialize mysqld. Please review /var/log/mysql/mysqld.err AND /var/tmp/portage/dev-db/mariadb-10.3.8/temp/mysql_install_db.log
 * 
 * Call stack:
 *     ebuild.sh, line  92:  Called pkg_config
 *   environment, line 5616:  Called die
 * The specific snippet of code:
 *           die "Failed to initialize mysqld. Please review ${EPREFIX}/var/log/mysql/mysqld.err AND ${TMPDIR}/mysql_install_db.log";
 * 
 * If you need support, post the output of `emerge --info '=dev-db/mariadb-10.3.8::dev-kit'`,
 * the complete build log and the output of `emerge -pqv '=dev-db/mariadb-10.3.8::dev-kit'`.
!!! When you file a bug report, please include the following information:
GENTOO_VM=  CLASSPATH="" JAVA_HOME=""
JAVACFLAGS="" COMPILER=""
and of course, the output of emerge --info =mariadb-10.3.8
 * The complete build log is located at '/var/tmp/portage/dev-db/mariadb-10.3.8/temp/build.log.gz'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-db/mariadb-10.3.8/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-db/mariadb-10.3.8/temp'
 * S: '/var/tmp/portage/dev-db/mariadb-10.3.8/work/mariadb-10.3.8'
```

worked after:
```
cat /etc/mysql/mariadb.d/50-distro-server.cnf.dist_0000 >> /etc/mysql/my.cnf
```
```
emerge --config dev-db/mariadb


Configuring pkg...

 * Trying to get password for mysql 'root' user from 'mysql' section ...
 * Trying to get password for mysql 'root' user from 'client' section ...
 * Please provide a password for the mysql 'root' user now
 * or through the /root/.my.cnf file.
 * Avoid ["'\_%] characters in the password
    >
 * Retype the password
    >
 * Creating the mysql database and setting proper permissions on it ...
 * Command: /usr/share/mariadb/scripts/mysql_install_db --basedir=/usr --loose-skip-grant-tables --loose-skip-host-cache --loose-skip-name-resolve --loose-skip-networking --loose-skip-slave-start --loose-skip-ssl --loose-skip-log-bin --loose-skip-relay-log --loose-skip-slow-query-log --loose-skip-external-locking --loose-skip-log-slave-updates --datadir=///var/lib/mysql --tmpdir=///tmp/
 * Starting mysqld ...
 * Command //usr/sbin/mysqld 		 --loose-skip-grant-tables --loose-skip-host-cache --loose-skip-name-resolve --loose-skip-networking --loose-skip-slave-start --loose-skip-ssl --loose-skip-log-bin --loose-skip-relay-log --loose-skip-slow-query-log --loose-skip-external-locking --loose-skip-log-slave-updates --user=mysql 		--log-warnings=0 		--basedir=//usr 		--datadir=///var/lib/mysql 		--max_allowed_packet=8M 	--net_buffer_length=16K 		--socket=//var/run/mysqld/mysqld20487.sock 		--pid-file=//var/run/mysqld/mysqld12087.pid
 * 		--tmpdir=///tmp/
.2018-09-18  0:30:10 0 [Note] //usr/sbin/mysqld (mysqld 10.3.8-MariaDB) starting as process 22378 ...                                                                                                                                  [ ok ]
 * Setting root password ...                                                                                                                                                                                                           [ ok ]
 * Loading "zoneinfo", this step may require a few seconds ...                                                                                                                                                                         [ ok ]
 * Stopping the server ...
 * Done
```

Installed version:
```
eix dev-db/mariadb
[I] dev-db/mariadb [1]
     Available versions:  10.3.8(0/18)^td {+backup bindist client-libs cracklib debug extraengine galera innodb-lz4 innodb-lzo innodb-snappy jdbc jemalloc kerberos latin1 libressl mroonga numa odbc oqgraph pam +perl profiling rocksdb selinux +server sphinx sst-mariabackup sst-rsync sst-xtrabackup static static-libs systemd systemtap tcmalloc test tokudb xml yassl ABI_MIPS="n32 n64 o32" ABI_PPC="32 64" ABI_S390="32 64" ABI_X86="32 64 x32" ELIBC="FreeBSD"}
     Installed versions:  10.3.8(0/18)^d(01:23:16 AM 09/17/2018)(backup cracklib extraengine pam perl server xml -bindist -client-libs -debug -galera -innodb-lz4 -innodb-lzo -innodb-snappy -jdbc -jemalloc -kerberos -latin1 -libressl -mroonga -numa -odbc -oqgraph -profiling -rocksdb -selinux -sphinx -sst-mariabackup -sst-rsync -sst-xtrabackup -static -static-libs -systemd -systemtap -tcmalloc -test -tokudb -yassl ABI_MIPS="-n32 -n64 -o32" ABI_PPC="-32 -64" ABI_S390="-32 -64" ABI_X86="64 -32 -x32" ELIBC="-FreeBSD")
     Homepage:            http://mariadb.org/
     Description:         An enhanced, drop-in replacement for MySQL
```
My profile:
```
# epro show

=== Enabled Profiles: ===

        arch: pure64
       build: current
     subarch: intel64-haswell-pure64
      flavor: core
     mix-ins: no-systemd


=== Python kit: ===

      branch: 3.4-prime

=== All inherited flavor from core flavor: ===

                         minimal (from core flavor)
```
/etc/make.conf 
```
MAKEOPTS="-j5"

ACCEPT_LICENSE="*"
LINGUAS="en_US en ru ru_RU"
FEATURES="${FEATURES} parallel-fetch"
FEATURES="${FEATURES} parallel-install"
FEATURES="${FEATURES} prelink-checksums"
FEATURES="${FEATURES} candy"
FEATURES="${FEATURES} compress-build-logs"

USE="${USE} php xfs -rsyslog -iptables -ipv6 bash-completion -qt5 video_cards_i965"
PHP_TARGETS="php7-2" 
```